### PR TITLE
Update to jquery-migrate 3.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,13 +43,13 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>1.9.0</version>
+            <version>3.0.0</version>
         </dependency>
     </dependencies>
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>3.1.0</upstream.version>
+        <upstream.version>3.3.2</upstream.version>
         <upstream.url>http://code.jquery.com/</upstream.url>
         <destinationDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destinationDir>
     </properties>
@@ -59,7 +59,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>wagon-maven-plugin</artifactId>
-                <version>1.0-beta-4</version>
+                <version>2.0.2</version>
                 <executions>
                     <execution>
                         <id>download-js</id>
@@ -91,7 +91,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.6</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>sonatype-nexus-staging</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>jquery-migrate</artifactId>
-    <version>3.1.1-SNAPSHOT</version>
+    <version>3.3.2-SNAPSHOT</version>
     <name>jquery-migrate</name>
     <description>WebJar for jquery-migrate</description>
     <url>http://webjars.org</url>


### PR DESCRIPTION
Hi @jamesward!

There is a new jquery-migrate version 3.3.2 out there. Would you mind updating your webjar?

I also updated the plugin versions for you.

Best wishes

Daniel